### PR TITLE
Make containsClassTarget run in constant time

### DIFF
--- a/src/main/java/net/neoforged/accesstransformer/parser/AccessTransformerList.java
+++ b/src/main/java/net/neoforged/accesstransformer/parser/AccessTransformerList.java
@@ -18,6 +18,7 @@ public class AccessTransformerList {
     private static final Logger LOGGER = LogManager.getLogger("AXFORM");
     private static final Marker AXFORM_MARKER = MarkerManager.getMarker("AXFORM");
     private final Map<Target<?>, AccessTransformer> accessTransformers = new HashMap<>();
+    private Set<Type> targetedClassCache = Collections.emptySet();
     private INameHandler nameHandler = new IdentityNameHandler();
 
     public void loadFromResource(final String resourceName) throws URISyntaxException, IOException {
@@ -44,6 +45,7 @@ public class AccessTransformerList {
         }
         this.accessTransformers.clear();
         this.accessTransformers.putAll(localATCopy);
+        this.targetedClassCache = this.accessTransformers.keySet().stream().map(Target::getASMType).collect(Collectors.toSet());
         LOGGER.debug(AXFORM_MARKER,"Loaded access transformer {} from path {}", resourceName, path);
     }
 
@@ -55,7 +57,6 @@ public class AccessTransformerList {
         return accessTransformers.values().stream().filter(e -> !e.isValid()).collect(Collectors.toList());
     }
 
-
     public Map<String, List<AccessTransformer>> getAccessTransformers() {
         return accessTransformers.entrySet().stream().collect(Collectors.groupingBy(
                 (Map.Entry<Target<?>, AccessTransformer> e) -> e.getValue().getTarget().getClassName(),
@@ -65,7 +66,7 @@ public class AccessTransformerList {
     }
 
     public boolean containsClassTarget(final Type type) {
-        return accessTransformers.keySet().stream().anyMatch(k->type.equals(k.getASMType()));
+        return targetedClassCache.contains(type);
     }
 
     public Map<TargetType, Map<String,AccessTransformer>> getTransformersForTarget(final Type type) {


### PR DESCRIPTION
The previous implementation of `containsClassTarget` would potentially iterate the whole list of access transformer targets to determine that a class should or should not be transformed. This is extremely poor time complexity (O(n)) and showed up frequently in my profiler reports.

The problem is easy to solve: we keep a set of the types contained in the AT map, and simply check that set. A significantly hackier version of this patch has been used in ModernFix for several months with no reported issues.