### PR TITLE
Use absolute paths in origin names

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -99,6 +99,7 @@ configurations {
 dependencies {
     testImplementation(libs.junit.api)
     testImplementation(libs.powermock)
+    testImplementation(libs.assert4j)
     testImplementation(libs.bsl)
     testImplementation(libs.sjh)
     testImplementation(libs.gson)

--- a/settings.gradle
+++ b/settings.gradle
@@ -16,6 +16,7 @@ dependencyResolutionManagement {
             library('slf4j', 'org.slf4j:slf4j-api:2.0.9')
             library('jopt', 'net.sf.jopt-simple:jopt-simple:6.0-alpha-3')
             library('jopt5', 'net.sf.jopt-simple:jopt-simple:5.0.4')
+            library('assert4j', 'org.assertj:assertj-core:3.25.1')
 
             library('log4j-api', 'org.apache.logging.log4j', 'log4j-api').versionRef(log4j)
             library('log4j-core', 'org.apache.logging.log4j', 'log4j-core').versionRef(log4j)

--- a/src/main/java/net/neoforged/accesstransformer/AccessTransformer.java
+++ b/src/main/java/net/neoforged/accesstransformer/AccessTransformer.java
@@ -8,6 +8,7 @@ import org.slf4j.MarkerFactory;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
@@ -48,7 +49,7 @@ public class AccessTransformer {
     }
 
     public List<String> getOrigins() {
-        return origins;
+        return Collections.unmodifiableList(origins);
     }
 
     public <T> void applyModifier(final T node, final Class<T> type, final Set<String> privateChanged) {

--- a/src/main/java/net/neoforged/accesstransformer/parser/AccessTransformerList.java
+++ b/src/main/java/net/neoforged/accesstransformer/parser/AccessTransformerList.java
@@ -39,7 +39,7 @@ public class AccessTransformerList {
                     StandardCharsets.UTF_8,
                     4096, // CharStreams.DEFAULT_BUFFER_SIZE
                     CodingErrorAction.REPLACE,
-                    path.getFileName().toString(),
+                    path.toAbsolutePath().toString(),
                     size));
         }
     }

--- a/src/test/java/net/neoforged/accesstransformer/test/AccessTransformerLoadTest.java
+++ b/src/test/java/net/neoforged/accesstransformer/test/AccessTransformerLoadTest.java
@@ -6,6 +6,7 @@ import com.google.gson.reflect.TypeToken;
 import net.neoforged.accesstransformer.AccessTransformer;
 import net.neoforged.accesstransformer.ml.AccessTransformerService;
 import net.neoforged.accesstransformer.parser.AccessTransformerList;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.powermock.reflect.Whitebox;
 
@@ -22,15 +23,13 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.stream.Collectors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 public class AccessTransformerLoadTest {
     @Test
     public void testLoadForgeAT() throws IOException, URISyntaxException {
         final AccessTransformerList atLoader = new AccessTransformerList();
         atLoader.loadFromResource("forge_at.cfg");
         final Map<String, List<AccessTransformer>> accessTransformers = atLoader.getAccessTransformers();
-        testText(accessTransformers);
+        testText(accessTransformers, Paths.get(ClassLoader.getSystemClassLoader().getResource("forge_at.cfg").toURI()));
     }
 
     @Test
@@ -41,11 +40,11 @@ public class AccessTransformerLoadTest {
             mls.engine.loadATFromPath(atPath);
             final AccessTransformerList list = Whitebox.getInternalState(mls.engine, "masterList");
             final Map<String, List<AccessTransformer>> accessTransformers = list.getAccessTransformers();
-            testText(accessTransformers);
+            testText(accessTransformers, atPath);
         }
     }
 
-    private static void testText(final Map<String, List<AccessTransformer>> accessTransformers) throws URISyntaxException, IOException {
+    private static void testText(final Map<String, List<AccessTransformer>> accessTransformers, Path source) throws URISyntaxException, IOException {
         accessTransformers.forEach((k,v) -> System.out.printf("Got %d ATs for %s:\n\t%s\n", v.size(), k, v.stream().map(Object::toString).collect(Collectors.joining("\n\t"))));
 
         final TreeMap<String, List<String>> testOutput = accessTransformers.entrySet().stream().collect(
@@ -57,13 +56,14 @@ public class AccessTransformerLoadTest {
                 )
         );
 
-        final String text = new String(Files.readAllBytes(Paths.get(ClassLoader.getSystemClassLoader().getResource("forge_at.cfg.json").toURI())), StandardCharsets.UTF_8);
+        final String text = Files.readString(Paths.get(ClassLoader.getSystemClassLoader().getResource("forge_at.cfg.json").toURI()), StandardCharsets.UTF_8);
         final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
         final TreeMap<String, List<String>> expectation = GSON.fromJson(text, new TypeToken<TreeMap<String, List<String>>>() {}.getType());
+        expectation.values().forEach(value -> value.replaceAll(str -> str.replace("{cfgfile}", source.toAbsolutePath().toString())));
 
         final String output = GSON.toJson(testOutput);
         final String expect = GSON.toJson(expectation);
 
-        assertEquals(expect, output);
+        Assertions.assertThat(output).isEqualToNormalizingNewlines(expect);
     }
 }

--- a/src/test/resources/forge_at.cfg.json
+++ b/src/test/resources/forge_at.cfg.json
@@ -1,418 +1,418 @@
 {
   "net.minecraft.block.Block": [
-    "net.minecraft.block.Block METHOD \u003cinit\u003e(Lnet/minecraft/block/material/Material;)V PUBLIC LEAVE forge_at.cfg:5",
-    "net.minecraft.block.Block METHOD func_149675_a(Z)Lnet/minecraft/block/Block; PUBLIC LEAVE forge_at.cfg:11",
-    "net.minecraft.block.Block METHOD func_149711_c(F)Lnet/minecraft/block/Block; PUBLIC LEAVE forge_at.cfg:7",
-    "net.minecraft.block.Block METHOD func_149713_g(I)Lnet/minecraft/block/Block; PUBLIC LEAVE forge_at.cfg:8",
-    "net.minecraft.block.Block METHOD func_149715_a(F)Lnet/minecraft/block/Block; PUBLIC LEAVE forge_at.cfg:9",
-    "net.minecraft.block.Block METHOD func_149722_s()Lnet/minecraft/block/Block; PUBLIC LEAVE forge_at.cfg:10",
-    "net.minecraft.block.Block METHOD func_149752_b(F)Lnet/minecraft/block/Block; PUBLIC LEAVE forge_at.cfg:6",
-    "net.minecraft.block.Block METHOD func_180637_b(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;I)V PUBLIC LEAVE forge_at.cfg:12"
+    "net.minecraft.block.Block METHOD \u003cinit\u003e(Lnet/minecraft/block/material/Material;)V PUBLIC LEAVE {cfgfile}:5",
+    "net.minecraft.block.Block METHOD func_149675_a(Z)Lnet/minecraft/block/Block; PUBLIC LEAVE {cfgfile}:11",
+    "net.minecraft.block.Block METHOD func_149711_c(F)Lnet/minecraft/block/Block; PUBLIC LEAVE {cfgfile}:7",
+    "net.minecraft.block.Block METHOD func_149713_g(I)Lnet/minecraft/block/Block; PUBLIC LEAVE {cfgfile}:8",
+    "net.minecraft.block.Block METHOD func_149715_a(F)Lnet/minecraft/block/Block; PUBLIC LEAVE {cfgfile}:9",
+    "net.minecraft.block.Block METHOD func_149722_s()Lnet/minecraft/block/Block; PUBLIC LEAVE {cfgfile}:10",
+    "net.minecraft.block.Block METHOD func_149752_b(F)Lnet/minecraft/block/Block; PUBLIC LEAVE {cfgfile}:6",
+    "net.minecraft.block.Block METHOD func_180637_b(Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;I)V PUBLIC LEAVE {cfgfile}:12"
   ],
   "net.minecraft.block.BlockFire": [
-    "net.minecraft.block.BlockFire METHOD func_176532_c(Lnet/minecraft/block/Block;)I PUBLIC LEAVE forge_at.cfg:14",
-    "net.minecraft.block.BlockFire METHOD func_176534_d(Lnet/minecraft/block/Block;)I PUBLIC LEAVE forge_at.cfg:15"
+    "net.minecraft.block.BlockFire METHOD func_176532_c(Lnet/minecraft/block/Block;)I PUBLIC LEAVE {cfgfile}:14",
+    "net.minecraft.block.BlockFire METHOD func_176534_d(Lnet/minecraft/block/Block;)I PUBLIC LEAVE {cfgfile}:15"
   ],
   "net.minecraft.block.state.BlockStateContainer": [
-    "net.minecraft.block.state.BlockStateContainer INNERCLASS StateImplementation PUBLIC LEAVE forge_at.cfg:103"
+    "net.minecraft.block.state.BlockStateContainer INNERCLASS StateImplementation PUBLIC LEAVE {cfgfile}:103"
   ],
   "net.minecraft.block.state.BlockStateContainer$StateImplementation": [
-    "net.minecraft.block.state.BlockStateContainer$StateImplementation CLASS PUBLIC LEAVE forge_at.cfg:103",
-    "net.minecraft.block.state.BlockStateContainer$StateImplementation FIELD field_177238_c PROTECTED LEAVE forge_at.cfg:105",
-    "net.minecraft.block.state.BlockStateContainer$StateImplementation METHOD \u003cinit\u003e(Lnet/minecraft/block/Block;Lcom/google/common/collect/ImmutableMap;)V PROTECTED LEAVE forge_at.cfg:104"
+    "net.minecraft.block.state.BlockStateContainer$StateImplementation CLASS PUBLIC LEAVE {cfgfile}:103",
+    "net.minecraft.block.state.BlockStateContainer$StateImplementation FIELD field_177238_c PROTECTED LEAVE {cfgfile}:105",
+    "net.minecraft.block.state.BlockStateContainer$StateImplementation METHOD \u003cinit\u003e(Lnet/minecraft/block/Block;Lcom/google/common/collect/ImmutableMap;)V PROTECTED LEAVE {cfgfile}:104"
   ],
   "net.minecraft.client.Minecraft": [
-    "net.minecraft.client.Minecraft FIELD field_110450_ap PUBLIC LEAVE forge_at.cfg:186",
-    "net.minecraft.client.Minecraft FIELD field_71446_o PUBLIC LEAVE forge_at.cfg:185",
-    "net.minecraft.client.Minecraft METHOD func_180510_a(Lnet/minecraft/client/renderer/texture/TextureManager;)V PUBLIC LEAVE forge_at.cfg:188",
-    "net.minecraft.client.Minecraft METHOD func_184119_a(Lnet/minecraft/item/ItemStack;Lnet/minecraft/tileentity/TileEntity;)Lnet/minecraft/item/ItemStack; PUBLIC LEAVE forge_at.cfg:189",
-    "net.minecraft.client.Minecraft METHOD func_71370_a(II)V PUBLIC LEAVE forge_at.cfg:187"
+    "net.minecraft.client.Minecraft FIELD field_110450_ap PUBLIC LEAVE {cfgfile}:186",
+    "net.minecraft.client.Minecraft FIELD field_71446_o PUBLIC LEAVE {cfgfile}:185",
+    "net.minecraft.client.Minecraft METHOD func_180510_a(Lnet/minecraft/client/renderer/texture/TextureManager;)V PUBLIC LEAVE {cfgfile}:188",
+    "net.minecraft.client.Minecraft METHOD func_184119_a(Lnet/minecraft/item/ItemStack;Lnet/minecraft/tileentity/TileEntity;)Lnet/minecraft/item/ItemStack; PUBLIC LEAVE {cfgfile}:189",
+    "net.minecraft.client.Minecraft METHOD func_71370_a(II)V PUBLIC LEAVE {cfgfile}:187"
   ],
   "net.minecraft.client.audio.SoundManager": [
-    "net.minecraft.client.audio.SoundManager FIELD field_148622_c PUBLIC LEAVE forge_at.cfg:3"
+    "net.minecraft.client.audio.SoundManager FIELD field_148622_c PUBLIC LEAVE {cfgfile}:3"
   ],
   "net.minecraft.client.entity.EntityPlayerSP": [
-    "net.minecraft.client.entity.EntityPlayerSP METHOD func_184816_a(Lnet/minecraft/entity/item/EntityItem;)Lnet/minecraft/item/ItemStack; PUBLIC LEAVE forge_at.cfg:171"
+    "net.minecraft.client.entity.EntityPlayerSP METHOD func_184816_a(Lnet/minecraft/entity/item/EntityItem;)Lnet/minecraft/item/ItemStack; PUBLIC LEAVE {cfgfile}:171"
   ],
   "net.minecraft.client.gui.FontRenderer": [
-    "net.minecraft.client.gui.FontRenderer FIELD field_111273_g PROTECTED LEAVE forge_at.cfg:227",
-    "net.minecraft.client.gui.FontRenderer FIELD field_78286_d PROTECTED LEAVE forge_at.cfg:225",
-    "net.minecraft.client.gui.FontRenderer FIELD field_78287_e PROTECTED LEAVE forge_at.cfg:226",
-    "net.minecraft.client.gui.FontRenderer FIELD field_78295_j PROTECTED LEAVE forge_at.cfg:228",
-    "net.minecraft.client.gui.FontRenderer FIELD field_78296_k PROTECTED LEAVE forge_at.cfg:229",
-    "net.minecraft.client.gui.FontRenderer METHOD func_78266_a(IZ)F PROTECTED LEAVE forge_at.cfg:230",
-    "net.minecraft.client.gui.FontRenderer METHOD func_78277_a(CZ)F PROTECTED LEAVE forge_at.cfg:231"
+    "net.minecraft.client.gui.FontRenderer FIELD field_111273_g PROTECTED LEAVE {cfgfile}:227",
+    "net.minecraft.client.gui.FontRenderer FIELD field_78286_d PROTECTED LEAVE {cfgfile}:225",
+    "net.minecraft.client.gui.FontRenderer FIELD field_78287_e PROTECTED LEAVE {cfgfile}:226",
+    "net.minecraft.client.gui.FontRenderer FIELD field_78295_j PROTECTED LEAVE {cfgfile}:228",
+    "net.minecraft.client.gui.FontRenderer FIELD field_78296_k PROTECTED LEAVE {cfgfile}:229",
+    "net.minecraft.client.gui.FontRenderer METHOD func_78266_a(IZ)F PROTECTED LEAVE {cfgfile}:230",
+    "net.minecraft.client.gui.FontRenderer METHOD func_78277_a(CZ)F PROTECTED LEAVE {cfgfile}:231"
   ],
   "net.minecraft.client.gui.GuiButton": [
-    "net.minecraft.client.gui.GuiButton FIELD field_146120_f PUBLIC LEAVE forge_at.cfg:200",
-    "net.minecraft.client.gui.GuiButton FIELD field_146121_g PUBLIC LEAVE forge_at.cfg:201"
+    "net.minecraft.client.gui.GuiButton FIELD field_146120_f PUBLIC LEAVE {cfgfile}:200",
+    "net.minecraft.client.gui.GuiButton FIELD field_146121_g PUBLIC LEAVE {cfgfile}:201"
   ],
   "net.minecraft.client.gui.GuiIngame": [
-    "net.minecraft.client.gui.GuiIngame FIELDWILDCARD PROTECTED LEAVE forge_at.cfg:68",
-    "net.minecraft.client.gui.GuiIngame METHODWILDCARD PROTECTED LEAVE forge_at.cfg:69"
+    "net.minecraft.client.gui.GuiIngame FIELDWILDCARD PROTECTED LEAVE {cfgfile}:68",
+    "net.minecraft.client.gui.GuiIngame METHODWILDCARD PROTECTED LEAVE {cfgfile}:69"
   ],
   "net.minecraft.client.gui.GuiOverlayDebug": [
-    "net.minecraft.client.gui.GuiOverlayDebug METHOD func_181554_e()V PUBLIC LEAVE forge_at.cfg:278"
+    "net.minecraft.client.gui.GuiOverlayDebug METHOD func_181554_e()V PUBLIC LEAVE {cfgfile}:278"
   ],
   "net.minecraft.client.gui.GuiScreen": [
-    "net.minecraft.client.gui.GuiScreen FIELD field_146297_k PUBLIC LEAVE forge_at.cfg:183"
+    "net.minecraft.client.gui.GuiScreen FIELD field_146297_k PUBLIC LEAVE {cfgfile}:183"
   ],
   "net.minecraft.client.gui.GuiSlot": [
-    "net.minecraft.client.gui.GuiSlot FIELD field_148149_f PUBLIC LEAVE forge_at.cfg:206",
-    "net.minecraft.client.gui.GuiSlot FIELD field_148151_d PUBLIC LEAVE forge_at.cfg:207",
-    "net.minecraft.client.gui.GuiSlot FIELD field_148152_e PUBLIC LEAVE forge_at.cfg:208",
-    "net.minecraft.client.gui.GuiSlot FIELD field_148153_b PUBLIC LEAVE forge_at.cfg:209",
-    "net.minecraft.client.gui.GuiSlot FIELD field_148154_c PUBLIC LEAVE forge_at.cfg:210",
-    "net.minecraft.client.gui.GuiSlot FIELD field_148155_a PUBLIC LEAVE forge_at.cfg:211",
-    "net.minecraft.client.gui.GuiSlot FIELD field_148158_l PUBLIC LEAVE forge_at.cfg:212",
-    "net.minecraft.client.gui.GuiSlot FIELD field_148160_j PUBLIC LEAVE forge_at.cfg:213"
+    "net.minecraft.client.gui.GuiSlot FIELD field_148149_f PUBLIC LEAVE {cfgfile}:206",
+    "net.minecraft.client.gui.GuiSlot FIELD field_148151_d PUBLIC LEAVE {cfgfile}:207",
+    "net.minecraft.client.gui.GuiSlot FIELD field_148152_e PUBLIC LEAVE {cfgfile}:208",
+    "net.minecraft.client.gui.GuiSlot FIELD field_148153_b PUBLIC LEAVE {cfgfile}:209",
+    "net.minecraft.client.gui.GuiSlot FIELD field_148154_c PUBLIC LEAVE {cfgfile}:210",
+    "net.minecraft.client.gui.GuiSlot FIELD field_148155_a PUBLIC LEAVE {cfgfile}:211",
+    "net.minecraft.client.gui.GuiSlot FIELD field_148158_l PUBLIC LEAVE {cfgfile}:212",
+    "net.minecraft.client.gui.GuiSlot FIELD field_148160_j PUBLIC LEAVE {cfgfile}:213"
   ],
   "net.minecraft.client.gui.GuiTextField": [
-    "net.minecraft.client.gui.GuiTextField FIELD field_146218_h PUBLIC REMOVEFINAL forge_at.cfg:203",
-    "net.minecraft.client.gui.GuiTextField FIELD field_146219_i PUBLIC REMOVEFINAL forge_at.cfg:204"
+    "net.minecraft.client.gui.GuiTextField FIELD field_146218_h PUBLIC REMOVEFINAL {cfgfile}:203",
+    "net.minecraft.client.gui.GuiTextField FIELD field_146219_i PUBLIC REMOVEFINAL {cfgfile}:204"
   ],
   "net.minecraft.client.multiplayer.WorldClient": [
-    "net.minecraft.client.multiplayer.WorldClient METHOD func_72847_b(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE forge_at.cfg:64",
-    "net.minecraft.client.multiplayer.WorldClient METHOD func_72923_a(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE forge_at.cfg:63"
+    "net.minecraft.client.multiplayer.WorldClient METHOD func_72847_b(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE {cfgfile}:64",
+    "net.minecraft.client.multiplayer.WorldClient METHOD func_72923_a(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE {cfgfile}:63"
   ],
   "net.minecraft.client.renderer.BufferBuilder": [
-    "net.minecraft.client.renderer.BufferBuilder METHOD func_178972_a(IIII)V PUBLIC LEAVE forge_at.cfg:143",
-    "net.minecraft.client.renderer.BufferBuilder METHOD func_78909_a(I)I PUBLIC LEAVE forge_at.cfg:142"
+    "net.minecraft.client.renderer.BufferBuilder METHOD func_178972_a(IIII)V PUBLIC LEAVE {cfgfile}:143",
+    "net.minecraft.client.renderer.BufferBuilder METHOD func_78909_a(I)I PUBLIC LEAVE {cfgfile}:142"
   ],
   "net.minecraft.client.renderer.EntityRenderer": [
-    "net.minecraft.client.renderer.EntityRenderer METHOD func_175069_a(Lnet/minecraft/util/ResourceLocation;)V PUBLIC LEAVE forge_at.cfg:165"
+    "net.minecraft.client.renderer.EntityRenderer METHOD func_175069_a(Lnet/minecraft/util/ResourceLocation;)V PUBLIC LEAVE {cfgfile}:165"
   ],
   "net.minecraft.client.renderer.block.model.ModelBakery": [
-    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177598_f PROTECTED LEAVE forge_at.cfg:111",
-    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177599_g PROTECTED LEAVE forge_at.cfg:112",
-    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177602_b PROTECTED LEAVE forge_at.cfg:110",
-    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177605_n PROTECTED LEAVE forge_at.cfg:115",
-    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177606_o PROTECTED LEAVE forge_at.cfg:116",
-    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177609_j PROTECTED LEAVE forge_at.cfg:113",
-    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177610_k PROTECTED LEAVE forge_at.cfg:114",
-    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177616_r PROTECTED LEAVE forge_at.cfg:119",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177569_a(Lnet/minecraft/client/renderer/block/model/ModelBlockDefinition;Lnet/minecraft/client/renderer/block/model/ModelResourceLocation;)V PROTECTED LEAVE forge_at.cfg:121",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177577_b()V PROTECTED LEAVE forge_at.cfg:133",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177580_d(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/ResourceLocation; PROTECTED LEAVE forge_at.cfg:131",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177581_b(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Z PROTECTED LEAVE forge_at.cfg:128",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177582_d(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Lnet/minecraft/client/renderer/block/model/ModelBlock; PROTECTED LEAVE forge_at.cfg:130",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177583_a(Ljava/lang/String;)Lnet/minecraft/util/ResourceLocation; PROTECTED LEAVE forge_at.cfg:126",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177585_a(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Ljava/util/Set; PROTECTED LEAVE forge_at.cfg:127",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177586_a(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/block/model/ModelBlockDefinition; PROTECTED LEAVE forge_at.cfg:122",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177587_c(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Z PROTECTED LEAVE forge_at.cfg:129",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177590_d()V PROTECTED LEAVE forge_at.cfg:134",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177592_e()V PROTECTED LEAVE forge_at.cfg:124",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177594_c(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/block/model/ModelBlock; PROTECTED LEAVE forge_at.cfg:123",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177595_c()V PROTECTED LEAVE forge_at.cfg:135",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177596_a(Lnet/minecraft/item/Item;)Ljava/util/List; PROTECTED LEAVE forge_at.cfg:125",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_188637_e()V PROTECTED LEAVE forge_at.cfg:136",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_188638_a(Lnet/minecraft/client/renderer/block/model/ModelResourceLocation;Lnet/minecraft/client/renderer/block/model/VariantList;)V PROTECTED LEAVE forge_at.cfg:137",
-    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_188640_b()V PROTECTED LEAVE forge_at.cfg:132"
+    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177598_f PROTECTED LEAVE {cfgfile}:111",
+    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177599_g PROTECTED LEAVE {cfgfile}:112",
+    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177602_b PROTECTED LEAVE {cfgfile}:110",
+    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177605_n PROTECTED LEAVE {cfgfile}:115",
+    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177606_o PROTECTED LEAVE {cfgfile}:116",
+    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177609_j PROTECTED LEAVE {cfgfile}:113",
+    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177610_k PROTECTED LEAVE {cfgfile}:114",
+    "net.minecraft.client.renderer.block.model.ModelBakery FIELD field_177616_r PROTECTED LEAVE {cfgfile}:119",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177569_a(Lnet/minecraft/client/renderer/block/model/ModelBlockDefinition;Lnet/minecraft/client/renderer/block/model/ModelResourceLocation;)V PROTECTED LEAVE {cfgfile}:121",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177577_b()V PROTECTED LEAVE {cfgfile}:133",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177580_d(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/util/ResourceLocation; PROTECTED LEAVE {cfgfile}:131",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177581_b(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Z PROTECTED LEAVE {cfgfile}:128",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177582_d(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Lnet/minecraft/client/renderer/block/model/ModelBlock; PROTECTED LEAVE {cfgfile}:130",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177583_a(Ljava/lang/String;)Lnet/minecraft/util/ResourceLocation; PROTECTED LEAVE {cfgfile}:126",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177585_a(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Ljava/util/Set; PROTECTED LEAVE {cfgfile}:127",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177586_a(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/block/model/ModelBlockDefinition; PROTECTED LEAVE {cfgfile}:122",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177587_c(Lnet/minecraft/client/renderer/block/model/ModelBlock;)Z PROTECTED LEAVE {cfgfile}:129",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177590_d()V PROTECTED LEAVE {cfgfile}:134",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177592_e()V PROTECTED LEAVE {cfgfile}:124",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177594_c(Lnet/minecraft/util/ResourceLocation;)Lnet/minecraft/client/renderer/block/model/ModelBlock; PROTECTED LEAVE {cfgfile}:123",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177595_c()V PROTECTED LEAVE {cfgfile}:135",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_177596_a(Lnet/minecraft/item/Item;)Ljava/util/List; PROTECTED LEAVE {cfgfile}:125",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_188637_e()V PROTECTED LEAVE {cfgfile}:136",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_188638_a(Lnet/minecraft/client/renderer/block/model/ModelResourceLocation;Lnet/minecraft/client/renderer/block/model/VariantList;)V PROTECTED LEAVE {cfgfile}:137",
+    "net.minecraft.client.renderer.block.model.ModelBakery METHOD func_188640_b()V PROTECTED LEAVE {cfgfile}:132"
   ],
   "net.minecraft.client.renderer.block.model.ModelBlock": [
-    "net.minecraft.client.renderer.block.model.ModelBlock FIELD field_178315_d PUBLIC LEAVE forge_at.cfg:107",
-    "net.minecraft.client.renderer.block.model.ModelBlock FIELD field_178318_c PUBLIC LEAVE forge_at.cfg:106",
-    "net.minecraft.client.renderer.block.model.ModelBlock FIELD field_178322_i PUBLIC LEAVE forge_at.cfg:108",
-    "net.minecraft.client.renderer.block.model.ModelBlock METHOD func_187966_f()Ljava/util/List; PUBLIC LEAVE forge_at.cfg:109"
+    "net.minecraft.client.renderer.block.model.ModelBlock FIELD field_178315_d PUBLIC LEAVE {cfgfile}:107",
+    "net.minecraft.client.renderer.block.model.ModelBlock FIELD field_178318_c PUBLIC LEAVE {cfgfile}:106",
+    "net.minecraft.client.renderer.block.model.ModelBlock FIELD field_178322_i PUBLIC LEAVE {cfgfile}:108",
+    "net.minecraft.client.renderer.block.model.ModelBlock METHOD func_187966_f()Ljava/util/List; PUBLIC LEAVE {cfgfile}:109"
   ],
   "net.minecraft.client.renderer.entity.RenderEntityItem": [
-    "net.minecraft.client.renderer.entity.RenderEntityItem METHOD func_177078_a(Lnet/minecraft/item/ItemStack;)I PROTECTED LEAVE forge_at.cfg:98"
+    "net.minecraft.client.renderer.entity.RenderEntityItem METHOD func_177078_a(Lnet/minecraft/item/ItemStack;)I PROTECTED LEAVE {cfgfile}:98"
   ],
   "net.minecraft.client.renderer.entity.RenderLivingBase": [
-    "net.minecraft.client.renderer.entity.RenderLivingBase METHOD func_177094_a(Lnet/minecraft/client/renderer/entity/layers/LayerRenderer;)Z PUBLIC LEAVE forge_at.cfg:267"
+    "net.minecraft.client.renderer.entity.RenderLivingBase METHOD func_177094_a(Lnet/minecraft/client/renderer/entity/layers/LayerRenderer;)Z PUBLIC LEAVE {cfgfile}:267"
   ],
   "net.minecraft.client.renderer.entity.RenderManager": [
-    "net.minecraft.client.renderer.entity.RenderManager FIELD field_78729_o PUBLIC LEAVE forge_at.cfg:160"
+    "net.minecraft.client.renderer.entity.RenderManager FIELD field_78729_o PUBLIC LEAVE {cfgfile}:160"
   ],
   "net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher": [
-    "net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher FIELD field_147557_n PUBLIC LEAVE forge_at.cfg:163",
-    "net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher FIELD field_147559_m PUBLIC LEAVE forge_at.cfg:162"
+    "net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher FIELD field_147557_n PUBLIC LEAVE {cfgfile}:163",
+    "net.minecraft.client.renderer.tileentity.TileEntityRendererDispatcher FIELD field_147559_m PUBLIC LEAVE {cfgfile}:162"
   ],
   "net.minecraft.command.EntitySelector": [
-    "net.minecraft.command.EntitySelector METHOD func_190826_c(Ljava/lang/String;)Ljava/lang/String; PUBLIC LEAVE forge_at.cfg:311"
+    "net.minecraft.command.EntitySelector METHOD func_190826_c(Ljava/lang/String;)Ljava/lang/String; PUBLIC LEAVE {cfgfile}:311"
   ],
   "net.minecraft.creativetab.CreativeTabs": [
-    "net.minecraft.creativetab.CreativeTabs FIELD field_78032_a PUBLIC REMOVEFINAL forge_at.cfg:53"
+    "net.minecraft.creativetab.CreativeTabs FIELD field_78032_a PUBLIC REMOVEFINAL {cfgfile}:53"
   ],
   "net.minecraft.entity.EntityLiving": [
-    "net.minecraft.entity.EntityLiving FIELD field_70714_bg PUBLIC LEAVE forge_at.cfg:178",
-    "net.minecraft.entity.EntityLiving FIELD field_70715_bh PUBLIC LEAVE forge_at.cfg:179"
+    "net.minecraft.entity.EntityLiving FIELD field_70714_bg PUBLIC LEAVE {cfgfile}:178",
+    "net.minecraft.entity.EntityLiving FIELD field_70715_bh PUBLIC LEAVE {cfgfile}:179"
   ],
   "net.minecraft.entity.EntityTrackerEntry": [
-    "net.minecraft.entity.EntityTrackerEntry FIELD field_73134_o PUBLIC LEAVE forge_at.cfg:22"
+    "net.minecraft.entity.EntityTrackerEntry FIELD field_73134_o PUBLIC LEAVE {cfgfile}:22"
   ],
   "net.minecraft.entity.ai.EntityAITasks": [
-    "net.minecraft.entity.ai.EntityAITasks FIELD field_75782_a PUBLIC LEAVE forge_at.cfg:84",
-    "net.minecraft.entity.ai.EntityAITasks INNERCLASS EntityAITaskEntry PUBLIC LEAVE forge_at.cfg:176"
+    "net.minecraft.entity.ai.EntityAITasks FIELD field_75782_a PUBLIC LEAVE {cfgfile}:84",
+    "net.minecraft.entity.ai.EntityAITasks INNERCLASS EntityAITaskEntry PUBLIC LEAVE {cfgfile}:176"
   ],
   "net.minecraft.entity.ai.EntityAITasks$EntityAITaskEntry": [
-    "net.minecraft.entity.ai.EntityAITasks$EntityAITaskEntry CLASS PUBLIC LEAVE forge_at.cfg:176"
+    "net.minecraft.entity.ai.EntityAITasks$EntityAITaskEntry CLASS PUBLIC LEAVE {cfgfile}:176"
   ],
   "net.minecraft.entity.item.EntityMinecartContainer": [
-    "net.minecraft.entity.item.EntityMinecartContainer FIELD field_94112_b PUBLIC LEAVE forge_at.cfg:181"
+    "net.minecraft.entity.item.EntityMinecartContainer FIELD field_94112_b PUBLIC LEAVE {cfgfile}:181"
   ],
   "net.minecraft.entity.item.EntityXPOrb": [
-    "net.minecraft.entity.item.EntityXPOrb FIELD field_70530_e PUBLIC LEAVE forge_at.cfg:86"
+    "net.minecraft.entity.item.EntityXPOrb FIELD field_70530_e PUBLIC LEAVE {cfgfile}:86"
   ],
   "net.minecraft.entity.monster.AbstractSkeleton": [
-    "net.minecraft.entity.monster.AbstractSkeleton METHOD func_190727_o()Lnet/minecraft/util/SoundEvent; PROTECTED LEAVE forge_at.cfg:299"
+    "net.minecraft.entity.monster.AbstractSkeleton METHOD func_190727_o()Lnet/minecraft/util/SoundEvent; PROTECTED LEAVE {cfgfile}:299"
   ],
   "net.minecraft.entity.monster.EntitySkeleton": [
-    "net.minecraft.entity.monster.EntitySkeleton METHOD func_190727_o()Lnet/minecraft/util/SoundEvent; PROTECTED LEAVE forge_at.cfg:308"
+    "net.minecraft.entity.monster.EntitySkeleton METHOD func_190727_o()Lnet/minecraft/util/SoundEvent; PROTECTED LEAVE {cfgfile}:308"
   ],
   "net.minecraft.entity.monster.EntityStray": [
-    "net.minecraft.entity.monster.EntityStray METHOD func_190727_o()Lnet/minecraft/util/SoundEvent; PROTECTED LEAVE forge_at.cfg:305"
+    "net.minecraft.entity.monster.EntityStray METHOD func_190727_o()Lnet/minecraft/util/SoundEvent; PROTECTED LEAVE {cfgfile}:305"
   ],
   "net.minecraft.entity.monster.EntityWitherSkeleton": [
-    "net.minecraft.entity.monster.EntityWitherSkeleton METHOD func_190727_o()Lnet/minecraft/util/SoundEvent; PROTECTED LEAVE forge_at.cfg:302"
+    "net.minecraft.entity.monster.EntityWitherSkeleton METHOD func_190727_o()Lnet/minecraft/util/SoundEvent; PROTECTED LEAVE {cfgfile}:302"
   ],
   "net.minecraft.entity.passive.EntityVillager": [
-    "net.minecraft.entity.passive.EntityVillager INNERCLASS EmeraldForItems PUBLIC LEAVE forge_at.cfg:216",
-    "net.minecraft.entity.passive.EntityVillager INNERCLASS ITradeList PUBLIC LEAVE forge_at.cfg:217",
-    "net.minecraft.entity.passive.EntityVillager INNERCLASS ItemAndEmeraldToItem PUBLIC LEAVE forge_at.cfg:218",
-    "net.minecraft.entity.passive.EntityVillager INNERCLASS ListEnchantedBookForEmeralds PUBLIC LEAVE forge_at.cfg:219",
-    "net.minecraft.entity.passive.EntityVillager INNERCLASS ListEnchantedItemForEmeralds PUBLIC LEAVE forge_at.cfg:220",
-    "net.minecraft.entity.passive.EntityVillager INNERCLASS ListItemForEmeralds PUBLIC LEAVE forge_at.cfg:221",
-    "net.minecraft.entity.passive.EntityVillager INNERCLASS PriceInfo PUBLIC LEAVE forge_at.cfg:222"
+    "net.minecraft.entity.passive.EntityVillager INNERCLASS EmeraldForItems PUBLIC LEAVE {cfgfile}:216",
+    "net.minecraft.entity.passive.EntityVillager INNERCLASS ITradeList PUBLIC LEAVE {cfgfile}:217",
+    "net.minecraft.entity.passive.EntityVillager INNERCLASS ItemAndEmeraldToItem PUBLIC LEAVE {cfgfile}:218",
+    "net.minecraft.entity.passive.EntityVillager INNERCLASS ListEnchantedBookForEmeralds PUBLIC LEAVE {cfgfile}:219",
+    "net.minecraft.entity.passive.EntityVillager INNERCLASS ListEnchantedItemForEmeralds PUBLIC LEAVE {cfgfile}:220",
+    "net.minecraft.entity.passive.EntityVillager INNERCLASS ListItemForEmeralds PUBLIC LEAVE {cfgfile}:221",
+    "net.minecraft.entity.passive.EntityVillager INNERCLASS PriceInfo PUBLIC LEAVE {cfgfile}:222"
   ],
   "net.minecraft.entity.passive.EntityVillager$EmeraldForItems": [
-    "net.minecraft.entity.passive.EntityVillager$EmeraldForItems CLASS PUBLIC LEAVE forge_at.cfg:216"
+    "net.minecraft.entity.passive.EntityVillager$EmeraldForItems CLASS PUBLIC LEAVE {cfgfile}:216"
   ],
   "net.minecraft.entity.passive.EntityVillager$ITradeList": [
-    "net.minecraft.entity.passive.EntityVillager$ITradeList CLASS PUBLIC LEAVE forge_at.cfg:217"
+    "net.minecraft.entity.passive.EntityVillager$ITradeList CLASS PUBLIC LEAVE {cfgfile}:217"
   ],
   "net.minecraft.entity.passive.EntityVillager$ItemAndEmeraldToItem": [
-    "net.minecraft.entity.passive.EntityVillager$ItemAndEmeraldToItem CLASS PUBLIC LEAVE forge_at.cfg:218"
+    "net.minecraft.entity.passive.EntityVillager$ItemAndEmeraldToItem CLASS PUBLIC LEAVE {cfgfile}:218"
   ],
   "net.minecraft.entity.passive.EntityVillager$ListEnchantedBookForEmeralds": [
-    "net.minecraft.entity.passive.EntityVillager$ListEnchantedBookForEmeralds CLASS PUBLIC LEAVE forge_at.cfg:219"
+    "net.minecraft.entity.passive.EntityVillager$ListEnchantedBookForEmeralds CLASS PUBLIC LEAVE {cfgfile}:219"
   ],
   "net.minecraft.entity.passive.EntityVillager$ListEnchantedItemForEmeralds": [
-    "net.minecraft.entity.passive.EntityVillager$ListEnchantedItemForEmeralds CLASS PUBLIC LEAVE forge_at.cfg:220"
+    "net.minecraft.entity.passive.EntityVillager$ListEnchantedItemForEmeralds CLASS PUBLIC LEAVE {cfgfile}:220"
   ],
   "net.minecraft.entity.passive.EntityVillager$ListItemForEmeralds": [
-    "net.minecraft.entity.passive.EntityVillager$ListItemForEmeralds CLASS PUBLIC LEAVE forge_at.cfg:221"
+    "net.minecraft.entity.passive.EntityVillager$ListItemForEmeralds CLASS PUBLIC LEAVE {cfgfile}:221"
   ],
   "net.minecraft.entity.passive.EntityVillager$PriceInfo": [
-    "net.minecraft.entity.passive.EntityVillager$PriceInfo CLASS PUBLIC LEAVE forge_at.cfg:222"
+    "net.minecraft.entity.passive.EntityVillager$PriceInfo CLASS PUBLIC LEAVE {cfgfile}:222"
   ],
   "net.minecraft.entity.player.EntityPlayer": [
-    "net.minecraft.entity.player.EntityPlayer METHOD func_184816_a(Lnet/minecraft/entity/item/EntityItem;)Lnet/minecraft/item/ItemStack; PUBLIC LEAVE forge_at.cfg:169",
-    "net.minecraft.entity.player.EntityPlayer METHOD func_71053_j()V PUBLIC LEAVE forge_at.cfg:20"
+    "net.minecraft.entity.player.EntityPlayer METHOD func_184816_a(Lnet/minecraft/entity/item/EntityItem;)Lnet/minecraft/item/ItemStack; PUBLIC LEAVE {cfgfile}:169",
+    "net.minecraft.entity.player.EntityPlayer METHOD func_71053_j()V PUBLIC LEAVE {cfgfile}:20"
   ],
   "net.minecraft.entity.player.EntityPlayerMP": [
-    "net.minecraft.entity.player.EntityPlayerMP FIELD field_71139_cq PUBLIC LEAVE forge_at.cfg:174",
-    "net.minecraft.entity.player.EntityPlayerMP METHOD func_71117_bO()V PUBLIC LEAVE forge_at.cfg:173"
+    "net.minecraft.entity.player.EntityPlayerMP FIELD field_71139_cq PUBLIC LEAVE {cfgfile}:174",
+    "net.minecraft.entity.player.EntityPlayerMP METHOD func_71117_bO()V PUBLIC LEAVE {cfgfile}:173"
   ],
   "net.minecraft.inventory.ContainerRepair": [
-    "net.minecraft.inventory.ContainerRepair FIELD field_82856_l PUBLIC LEAVE forge_at.cfg:49"
+    "net.minecraft.inventory.ContainerRepair FIELD field_82856_l PUBLIC LEAVE {cfgfile}:49"
   ],
   "net.minecraft.item.Item": [
-    "net.minecraft.item.Item METHOD func_77627_a(Z)Lnet/minecraft/item/Item; PUBLIC LEAVE forge_at.cfg:18",
-    "net.minecraft.item.Item METHOD func_77656_e(I)Lnet/minecraft/item/Item; PUBLIC LEAVE forge_at.cfg:17"
+    "net.minecraft.item.Item METHOD func_77627_a(Z)Lnet/minecraft/item/Item; PUBLIC LEAVE {cfgfile}:18",
+    "net.minecraft.item.Item METHOD func_77656_e(I)Lnet/minecraft/item/Item; PUBLIC LEAVE {cfgfile}:17"
   ],
   "net.minecraft.item.ItemStack": [
-    "net.minecraft.item.ItemStack FIELD field_77991_e DEFAULT LEAVE forge_at.cfg:71"
+    "net.minecraft.item.ItemStack FIELD field_77991_e DEFAULT LEAVE {cfgfile}:71"
   ],
   "net.minecraft.item.crafting.RecipeTippedArrow": [
-    "net.minecraft.item.crafting.RecipeTippedArrow CLASS PUBLIC LEAVE forge_at.cfg:99"
+    "net.minecraft.item.crafting.RecipeTippedArrow CLASS PUBLIC LEAVE {cfgfile}:99"
   ],
   "net.minecraft.item.crafting.RecipesBanners": [
-    "net.minecraft.item.crafting.RecipesBanners INNERCLASS RecipeAddPattern PUBLIC LEAVE forge_at.cfg:101",
-    "net.minecraft.item.crafting.RecipesBanners INNERCLASS RecipeDuplicatePattern PUBLIC LEAVE forge_at.cfg:102"
+    "net.minecraft.item.crafting.RecipesBanners INNERCLASS RecipeAddPattern PUBLIC LEAVE {cfgfile}:101",
+    "net.minecraft.item.crafting.RecipesBanners INNERCLASS RecipeDuplicatePattern PUBLIC LEAVE {cfgfile}:102"
   ],
   "net.minecraft.item.crafting.RecipesBanners$RecipeAddPattern": [
-    "net.minecraft.item.crafting.RecipesBanners$RecipeAddPattern CLASS PUBLIC LEAVE forge_at.cfg:101"
+    "net.minecraft.item.crafting.RecipesBanners$RecipeAddPattern CLASS PUBLIC LEAVE {cfgfile}:101"
   ],
   "net.minecraft.item.crafting.RecipesBanners$RecipeDuplicatePattern": [
-    "net.minecraft.item.crafting.RecipesBanners$RecipeDuplicatePattern CLASS PUBLIC LEAVE forge_at.cfg:102"
+    "net.minecraft.item.crafting.RecipesBanners$RecipeDuplicatePattern CLASS PUBLIC LEAVE {cfgfile}:102"
   ],
   "net.minecraft.item.crafting.ShapedRecipes": [
-    "net.minecraft.item.crafting.ShapedRecipes FIELD field_77574_d PUBLIC MAKEFINAL forge_at.cfg:43",
-    "net.minecraft.item.crafting.ShapedRecipes FIELD field_77576_b PUBLIC MAKEFINAL forge_at.cfg:44",
-    "net.minecraft.item.crafting.ShapedRecipes FIELD field_77577_c PUBLIC MAKEFINAL forge_at.cfg:45"
+    "net.minecraft.item.crafting.ShapedRecipes FIELD field_77574_d PUBLIC MAKEFINAL {cfgfile}:43",
+    "net.minecraft.item.crafting.ShapedRecipes FIELD field_77576_b PUBLIC MAKEFINAL {cfgfile}:44",
+    "net.minecraft.item.crafting.ShapedRecipes FIELD field_77577_c PUBLIC MAKEFINAL {cfgfile}:45"
   ],
   "net.minecraft.item.crafting.ShapelessRecipes": [
-    "net.minecraft.item.crafting.ShapelessRecipes FIELD field_77579_b PUBLIC LEAVE forge_at.cfg:47"
+    "net.minecraft.item.crafting.ShapelessRecipes FIELD field_77579_b PUBLIC LEAVE {cfgfile}:47"
   ],
   "net.minecraft.item.crafting.ShieldRecipes": [
-    "net.minecraft.item.crafting.ShieldRecipes INNERCLASS Decoration PUBLIC LEAVE forge_at.cfg:100"
+    "net.minecraft.item.crafting.ShieldRecipes INNERCLASS Decoration PUBLIC LEAVE {cfgfile}:100"
   ],
   "net.minecraft.item.crafting.ShieldRecipes$Decoration": [
-    "net.minecraft.item.crafting.ShieldRecipes$Decoration CLASS PUBLIC LEAVE forge_at.cfg:100"
+    "net.minecraft.item.crafting.ShieldRecipes$Decoration CLASS PUBLIC LEAVE {cfgfile}:100"
   ],
   "net.minecraft.nbt.NBTPrimitive": [
-    "net.minecraft.nbt.NBTPrimitive CLASS PUBLIC LEAVE forge_at.cfg:275"
+    "net.minecraft.nbt.NBTPrimitive CLASS PUBLIC LEAVE {cfgfile}:275"
   ],
   "net.minecraft.network.play.server.SPacketBlockChange": [
-    "net.minecraft.network.play.server.SPacketBlockChange FIELD field_148883_d PUBLIC LEAVE forge_at.cfg:78"
+    "net.minecraft.network.play.server.SPacketBlockChange FIELD field_148883_d PUBLIC LEAVE {cfgfile}:78"
   ],
   "net.minecraft.network.status.server.SPacketServerInfo": [
-    "net.minecraft.network.status.server.SPacketServerInfo FIELD field_149297_a PUBLIC LEAVE forge_at.cfg:150"
+    "net.minecraft.network.status.server.SPacketServerInfo FIELD field_149297_a PUBLIC LEAVE {cfgfile}:150"
   ],
   "net.minecraft.potion.PotionHelper": [
-    "net.minecraft.potion.PotionHelper INNERCLASS MixPredicate PUBLIC LEAVE forge_at.cfg:281",
-    "net.minecraft.potion.PotionHelper METHOD func_193354_a(Lnet/minecraft/item/ItemPotion;)V PUBLIC LEAVE forge_at.cfg:283",
-    "net.minecraft.potion.PotionHelper METHOD func_193355_a(Lnet/minecraft/item/ItemPotion;Lnet/minecraft/item/Item;Lnet/minecraft/item/ItemPotion;)V PUBLIC LEAVE forge_at.cfg:282",
-    "net.minecraft.potion.PotionHelper METHOD func_193356_a(Lnet/minecraft/potion/PotionType;Lnet/minecraft/item/crafting/Ingredient;Lnet/minecraft/potion/PotionType;)V PUBLIC LEAVE forge_at.cfg:285",
-    "net.minecraft.potion.PotionHelper METHOD func_193357_a(Lnet/minecraft/potion/PotionType;Lnet/minecraft/item/Item;Lnet/minecraft/potion/PotionType;)V PUBLIC LEAVE forge_at.cfg:284"
+    "net.minecraft.potion.PotionHelper INNERCLASS MixPredicate PUBLIC LEAVE {cfgfile}:281",
+    "net.minecraft.potion.PotionHelper METHOD func_193354_a(Lnet/minecraft/item/ItemPotion;)V PUBLIC LEAVE {cfgfile}:283",
+    "net.minecraft.potion.PotionHelper METHOD func_193355_a(Lnet/minecraft/item/ItemPotion;Lnet/minecraft/item/Item;Lnet/minecraft/item/ItemPotion;)V PUBLIC LEAVE {cfgfile}:282",
+    "net.minecraft.potion.PotionHelper METHOD func_193356_a(Lnet/minecraft/potion/PotionType;Lnet/minecraft/item/crafting/Ingredient;Lnet/minecraft/potion/PotionType;)V PUBLIC LEAVE {cfgfile}:285",
+    "net.minecraft.potion.PotionHelper METHOD func_193357_a(Lnet/minecraft/potion/PotionType;Lnet/minecraft/item/Item;Lnet/minecraft/potion/PotionType;)V PUBLIC LEAVE {cfgfile}:284"
   ],
   "net.minecraft.potion.PotionHelper$MixPredicate": [
-    "net.minecraft.potion.PotionHelper$MixPredicate CLASS PUBLIC LEAVE forge_at.cfg:281"
+    "net.minecraft.potion.PotionHelper$MixPredicate CLASS PUBLIC LEAVE {cfgfile}:281"
   ],
   "net.minecraft.server.dedicated.DedicatedServer": [
-    "net.minecraft.server.dedicated.DedicatedServer FIELD field_71341_l PUBLIC LEAVE forge_at.cfg:191"
+    "net.minecraft.server.dedicated.DedicatedServer FIELD field_71341_l PUBLIC LEAVE {cfgfile}:191"
   ],
   "net.minecraft.server.management.PlayerChunkMapEntry": [
-    "net.minecraft.server.management.PlayerChunkMapEntry FIELD field_187285_e PRIVATE REMOVEFINAL forge_at.cfg:264"
+    "net.minecraft.server.management.PlayerChunkMapEntry FIELD field_187285_e PRIVATE REMOVEFINAL {cfgfile}:264"
   ],
   "net.minecraft.tileentity.TileEntity": [
-    "net.minecraft.tileentity.TileEntity METHOD func_190560_a(Ljava/lang/String;Ljava/lang/Class;)V PUBLIC LEAVE forge_at.cfg:288"
+    "net.minecraft.tileentity.TileEntity METHOD func_190560_a(Ljava/lang/String;Ljava/lang/Class;)V PUBLIC LEAVE {cfgfile}:288"
   ],
   "net.minecraft.tileentity.TileEntityHopper": [
-    "net.minecraft.tileentity.TileEntityHopper METHOD func_145887_i()Z PROTECTED LEAVE forge_at.cfg:293",
-    "net.minecraft.tileentity.TileEntityHopper METHOD func_145896_c(I)V PUBLIC LEAVE forge_at.cfg:292",
-    "net.minecraft.tileentity.TileEntityHopper METHOD func_174914_o()Z PUBLIC LEAVE forge_at.cfg:291"
+    "net.minecraft.tileentity.TileEntityHopper METHOD func_145887_i()Z PROTECTED LEAVE {cfgfile}:293",
+    "net.minecraft.tileentity.TileEntityHopper METHOD func_145896_c(I)V PUBLIC LEAVE {cfgfile}:292",
+    "net.minecraft.tileentity.TileEntityHopper METHOD func_174914_o()Z PUBLIC LEAVE {cfgfile}:291"
   ],
   "net.minecraft.util.DamageSource": [
-    "net.minecraft.util.DamageSource METHODWILDCARD PUBLIC LEAVE forge_at.cfg:82"
+    "net.minecraft.util.DamageSource METHODWILDCARD PUBLIC LEAVE {cfgfile}:82"
   ],
   "net.minecraft.util.EnumFacing": [
-    "net.minecraft.util.EnumFacing FIELD field_176754_o PUBLIC LEAVE forge_at.cfg:141",
-    "net.minecraft.util.EnumFacing FIELD field_82609_l PUBLIC LEAVE forge_at.cfg:140"
+    "net.minecraft.util.EnumFacing FIELD field_176754_o PUBLIC LEAVE {cfgfile}:141",
+    "net.minecraft.util.EnumFacing FIELD field_82609_l PUBLIC LEAVE {cfgfile}:140"
   ],
   "net.minecraft.util.ObjectIntIdentityMap": [
-    "net.minecraft.util.ObjectIntIdentityMap FIELD field_148748_b PROTECTED LEAVE forge_at.cfg:196",
-    "net.minecraft.util.ObjectIntIdentityMap FIELD field_148749_a PROTECTED LEAVE forge_at.cfg:195"
+    "net.minecraft.util.ObjectIntIdentityMap FIELD field_148748_b PROTECTED LEAVE {cfgfile}:196",
+    "net.minecraft.util.ObjectIntIdentityMap FIELD field_148749_a PROTECTED LEAVE {cfgfile}:195"
   ],
   "net.minecraft.util.ResourceLocation": [
-    "net.minecraft.util.ResourceLocation METHOD func_177516_a(Ljava/lang/String;)[Ljava/lang/String; PUBLIC LEAVE forge_at.cfg:318"
+    "net.minecraft.util.ResourceLocation METHOD func_177516_a(Ljava/lang/String;)[Ljava/lang/String; PUBLIC LEAVE {cfgfile}:318"
   ],
   "net.minecraft.util.WeightedRandom$Item": [
-    "net.minecraft.util.WeightedRandom$Item FIELD field_76292_a PUBLIC LEAVE forge_at.cfg:167"
+    "net.minecraft.util.WeightedRandom$Item FIELD field_76292_a PUBLIC LEAVE {cfgfile}:167"
   ],
   "net.minecraft.util.datafix.DataFixer": [
-    "net.minecraft.util.datafix.DataFixer FIELD field_188262_d PUBLIC LEAVE forge_at.cfg:296"
+    "net.minecraft.util.datafix.DataFixer FIELD field_188262_d PUBLIC LEAVE {cfgfile}:296"
   ],
   "net.minecraft.world.Teleporter": [
-    "net.minecraft.world.Teleporter FIELD field_77187_a PROTECTED LEAVE forge_at.cfg:315",
-    "net.minecraft.world.Teleporter FIELD field_85191_c PROTECTED LEAVE forge_at.cfg:316",
-    "net.minecraft.world.Teleporter FIELD field_85192_a PROTECTED LEAVE forge_at.cfg:314"
+    "net.minecraft.world.Teleporter FIELD field_77187_a PROTECTED LEAVE {cfgfile}:315",
+    "net.minecraft.world.Teleporter FIELD field_85191_c PROTECTED LEAVE {cfgfile}:316",
+    "net.minecraft.world.Teleporter FIELD field_85192_a PROTECTED LEAVE {cfgfile}:314"
   ],
   "net.minecraft.world.World": [
-    "net.minecraft.world.World FIELD field_72982_D PUBLIC REMOVEFINAL forge_at.cfg:27",
-    "net.minecraft.world.World FIELD field_73003_n PUBLIC LEAVE forge_at.cfg:55",
-    "net.minecraft.world.World FIELD field_73004_o PUBLIC LEAVE forge_at.cfg:56",
-    "net.minecraft.world.World FIELD field_73017_q PUBLIC LEAVE forge_at.cfg:57",
-    "net.minecraft.world.World FIELD field_73018_p PUBLIC LEAVE forge_at.cfg:58",
-    "net.minecraft.world.World METHOD func_175701_a(Lnet/minecraft/util/math/BlockPos;)Z PUBLIC LEAVE forge_at.cfg:65",
-    "net.minecraft.world.World METHOD func_189509_E(Lnet/minecraft/util/math/BlockPos;)Z PUBLIC LEAVE forge_at.cfg:66",
-    "net.minecraft.world.World METHOD func_72847_b(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE forge_at.cfg:60",
-    "net.minecraft.world.World METHOD func_72923_a(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE forge_at.cfg:59"
+    "net.minecraft.world.World FIELD field_72982_D PUBLIC REMOVEFINAL {cfgfile}:27",
+    "net.minecraft.world.World FIELD field_73003_n PUBLIC LEAVE {cfgfile}:55",
+    "net.minecraft.world.World FIELD field_73004_o PUBLIC LEAVE {cfgfile}:56",
+    "net.minecraft.world.World FIELD field_73017_q PUBLIC LEAVE {cfgfile}:57",
+    "net.minecraft.world.World FIELD field_73018_p PUBLIC LEAVE {cfgfile}:58",
+    "net.minecraft.world.World METHOD func_175701_a(Lnet/minecraft/util/math/BlockPos;)Z PUBLIC LEAVE {cfgfile}:65",
+    "net.minecraft.world.World METHOD func_189509_E(Lnet/minecraft/util/math/BlockPos;)Z PUBLIC LEAVE {cfgfile}:66",
+    "net.minecraft.world.World METHOD func_72847_b(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE {cfgfile}:60",
+    "net.minecraft.world.World METHOD func_72923_a(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE {cfgfile}:59"
   ],
   "net.minecraft.world.WorldServer": [
-    "net.minecraft.world.WorldServer METHOD func_72847_b(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE forge_at.cfg:62",
-    "net.minecraft.world.WorldServer METHOD func_72923_a(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE forge_at.cfg:61"
+    "net.minecraft.world.WorldServer METHOD func_72847_b(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE {cfgfile}:62",
+    "net.minecraft.world.WorldServer METHOD func_72923_a(Lnet/minecraft/entity/Entity;)V PUBLIC LEAVE {cfgfile}:61"
   ],
   "net.minecraft.world.WorldType": [
-    "net.minecraft.world.WorldType FIELD field_77139_a PUBLIC REMOVEFINAL forge_at.cfg:80"
+    "net.minecraft.world.WorldType FIELD field_77139_a PUBLIC REMOVEFINAL {cfgfile}:80"
   ],
   "net.minecraft.world.biome.Biome": [
-    "net.minecraft.world.biome.Biome METHODWILDCARD PUBLIC LEAVE forge_at.cfg:29"
+    "net.minecraft.world.biome.Biome METHODWILDCARD PUBLIC LEAVE {cfgfile}:29"
   ],
   "net.minecraft.world.biome.Biome$BiomeProperties": [
-    "net.minecraft.world.biome.Biome$BiomeProperties METHODWILDCARD PUBLIC LEAVE forge_at.cfg:37"
+    "net.minecraft.world.biome.Biome$BiomeProperties METHODWILDCARD PUBLIC LEAVE {cfgfile}:37"
   ],
   "net.minecraft.world.biome.BiomeDecorator": [
-    "net.minecraft.world.biome.BiomeDecorator FIELDWILDCARD PUBLIC LEAVE forge_at.cfg:51"
+    "net.minecraft.world.biome.BiomeDecorator FIELDWILDCARD PUBLIC LEAVE {cfgfile}:51"
   ],
   "net.minecraft.world.biome.BiomeForest": [
-    "net.minecraft.world.biome.BiomeForest METHODWILDCARD PUBLIC LEAVE forge_at.cfg:30"
+    "net.minecraft.world.biome.BiomeForest METHODWILDCARD PUBLIC LEAVE {cfgfile}:30"
   ],
   "net.minecraft.world.biome.BiomeHills": [
-    "net.minecraft.world.biome.BiomeHills METHODWILDCARD PUBLIC LEAVE forge_at.cfg:31"
+    "net.minecraft.world.biome.BiomeHills METHODWILDCARD PUBLIC LEAVE {cfgfile}:31"
   ],
   "net.minecraft.world.biome.BiomeMesa": [
-    "net.minecraft.world.biome.BiomeMesa METHODWILDCARD PUBLIC LEAVE forge_at.cfg:32"
+    "net.minecraft.world.biome.BiomeMesa METHODWILDCARD PUBLIC LEAVE {cfgfile}:32"
   ],
   "net.minecraft.world.biome.BiomePlains": [
-    "net.minecraft.world.biome.BiomePlains METHODWILDCARD PUBLIC LEAVE forge_at.cfg:33"
+    "net.minecraft.world.biome.BiomePlains METHODWILDCARD PUBLIC LEAVE {cfgfile}:33"
   ],
   "net.minecraft.world.biome.BiomeSavanna": [
-    "net.minecraft.world.biome.BiomeSavanna METHODWILDCARD PUBLIC LEAVE forge_at.cfg:34"
+    "net.minecraft.world.biome.BiomeSavanna METHODWILDCARD PUBLIC LEAVE {cfgfile}:34"
   ],
   "net.minecraft.world.biome.BiomeSnow": [
-    "net.minecraft.world.biome.BiomeSnow METHODWILDCARD PUBLIC LEAVE forge_at.cfg:35"
+    "net.minecraft.world.biome.BiomeSnow METHODWILDCARD PUBLIC LEAVE {cfgfile}:35"
   ],
   "net.minecraft.world.biome.BiomeTaiga": [
-    "net.minecraft.world.biome.BiomeTaiga METHODWILDCARD PUBLIC LEAVE forge_at.cfg:36"
+    "net.minecraft.world.biome.BiomeTaiga METHODWILDCARD PUBLIC LEAVE {cfgfile}:36"
   ],
   "net.minecraft.world.chunk.storage.AnvilChunkLoader": [
-    "net.minecraft.world.chunk.storage.AnvilChunkLoader FIELD field_75825_d PUBLIC LEAVE forge_at.cfg:24"
+    "net.minecraft.world.chunk.storage.AnvilChunkLoader FIELD field_75825_d PUBLIC LEAVE {cfgfile}:24"
   ],
   "net.minecraft.world.gen.ChunkGeneratorEnd": [
-    "net.minecraft.world.gen.ChunkGeneratorEnd FIELD field_185969_i PRIVATE REMOVEFINAL forge_at.cfg:234",
-    "net.minecraft.world.gen.ChunkGeneratorEnd FIELD field_185970_j PRIVATE REMOVEFINAL forge_at.cfg:235",
-    "net.minecraft.world.gen.ChunkGeneratorEnd FIELD field_185971_k PRIVATE REMOVEFINAL forge_at.cfg:236",
-    "net.minecraft.world.gen.ChunkGeneratorEnd FIELD field_185973_o PRIVATE REMOVEFINAL forge_at.cfg:237"
+    "net.minecraft.world.gen.ChunkGeneratorEnd FIELD field_185969_i PRIVATE REMOVEFINAL {cfgfile}:234",
+    "net.minecraft.world.gen.ChunkGeneratorEnd FIELD field_185970_j PRIVATE REMOVEFINAL {cfgfile}:235",
+    "net.minecraft.world.gen.ChunkGeneratorEnd FIELD field_185971_k PRIVATE REMOVEFINAL {cfgfile}:236",
+    "net.minecraft.world.gen.ChunkGeneratorEnd FIELD field_185973_o PRIVATE REMOVEFINAL {cfgfile}:237"
   ],
   "net.minecraft.world.gen.ChunkGeneratorHell": [
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185939_I PRIVATE REMOVEFINAL forge_at.cfg:260",
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185946_g PUBLIC REMOVEFINAL forge_at.cfg:258",
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185947_h PUBLIC REMOVEFINAL forge_at.cfg:259",
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185957_u PRIVATE REMOVEFINAL forge_at.cfg:253",
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185958_v PRIVATE REMOVEFINAL forge_at.cfg:254",
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185959_w PRIVATE REMOVEFINAL forge_at.cfg:255",
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_73172_c PRIVATE REMOVEFINAL forge_at.cfg:261",
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_73174_n PRIVATE REMOVEFINAL forge_at.cfg:257",
-    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_73177_m PRIVATE REMOVEFINAL forge_at.cfg:256"
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185939_I PRIVATE REMOVEFINAL {cfgfile}:260",
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185946_g PUBLIC REMOVEFINAL {cfgfile}:258",
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185947_h PUBLIC REMOVEFINAL {cfgfile}:259",
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185957_u PRIVATE REMOVEFINAL {cfgfile}:253",
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185958_v PRIVATE REMOVEFINAL {cfgfile}:254",
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_185959_w PRIVATE REMOVEFINAL {cfgfile}:255",
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_73172_c PRIVATE REMOVEFINAL {cfgfile}:261",
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_73174_n PRIVATE REMOVEFINAL {cfgfile}:257",
+    "net.minecraft.world.gen.ChunkGeneratorHell FIELD field_73177_m PRIVATE REMOVEFINAL {cfgfile}:256"
   ],
   "net.minecraft.world.gen.ChunkGeneratorOverworld": [
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185979_A PRIVATE REMOVEFINAL forge_at.cfg:244",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185980_B PRIVATE REMOVEFINAL forge_at.cfg:245",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185991_j PRIVATE REMOVEFINAL forge_at.cfg:240",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185992_k PRIVATE REMOVEFINAL forge_at.cfg:241",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185993_l PRIVATE REMOVEFINAL forge_at.cfg:242",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185994_m PRIVATE REMOVEFINAL forge_at.cfg:243",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186003_v PRIVATE REMOVEFINAL forge_at.cfg:246",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186004_w PRIVATE REMOVEFINAL forge_at.cfg:247",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186005_x PRIVATE REMOVEFINAL forge_at.cfg:248",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186006_y PRIVATE REMOVEFINAL forge_at.cfg:249",
-    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186007_z PRIVATE REMOVEFINAL forge_at.cfg:250"
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185979_A PRIVATE REMOVEFINAL {cfgfile}:244",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185980_B PRIVATE REMOVEFINAL {cfgfile}:245",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185991_j PRIVATE REMOVEFINAL {cfgfile}:240",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185992_k PRIVATE REMOVEFINAL {cfgfile}:241",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185993_l PRIVATE REMOVEFINAL {cfgfile}:242",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_185994_m PRIVATE REMOVEFINAL {cfgfile}:243",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186003_v PRIVATE REMOVEFINAL {cfgfile}:246",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186004_w PRIVATE REMOVEFINAL {cfgfile}:247",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186005_x PRIVATE REMOVEFINAL {cfgfile}:248",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186006_y PRIVATE REMOVEFINAL {cfgfile}:249",
+    "net.minecraft.world.gen.ChunkGeneratorOverworld FIELD field_186007_z PRIVATE REMOVEFINAL {cfgfile}:250"
   ],
   "net.minecraft.world.gen.ChunkProviderServer": [
-    "net.minecraft.world.gen.ChunkProviderServer FIELD field_186029_c PUBLIC LEAVE forge_at.cfg:92",
-    "net.minecraft.world.gen.ChunkProviderServer FIELD field_73244_f PUBLIC LEAVE forge_at.cfg:93",
-    "net.minecraft.world.gen.ChunkProviderServer FIELD field_73247_e PUBLIC LEAVE forge_at.cfg:25",
-    "net.minecraft.world.gen.ChunkProviderServer FIELD field_73251_h PUBLIC LEAVE forge_at.cfg:95"
+    "net.minecraft.world.gen.ChunkProviderServer FIELD field_186029_c PUBLIC LEAVE {cfgfile}:92",
+    "net.minecraft.world.gen.ChunkProviderServer FIELD field_73244_f PUBLIC LEAVE {cfgfile}:93",
+    "net.minecraft.world.gen.ChunkProviderServer FIELD field_73247_e PUBLIC LEAVE {cfgfile}:25",
+    "net.minecraft.world.gen.ChunkProviderServer FIELD field_73251_h PUBLIC LEAVE {cfgfile}:95"
   ],
   "net.minecraft.world.gen.structure.MapGenStronghold": [
-    "net.minecraft.world.gen.structure.MapGenStronghold FIELD field_151546_e PUBLIC MAKEFINAL forge_at.cfg:39"
+    "net.minecraft.world.gen.structure.MapGenStronghold FIELD field_151546_e PUBLIC MAKEFINAL {cfgfile}:39"
   ],
   "net.minecraft.world.gen.structure.MapGenStructureIO": [
-    "net.minecraft.world.gen.structure.MapGenStructureIO METHOD func_143031_a(Ljava/lang/Class;Ljava/lang/String;)V PUBLIC LEAVE forge_at.cfg:74",
-    "net.minecraft.world.gen.structure.MapGenStructureIO METHOD func_143034_b(Ljava/lang/Class;Ljava/lang/String;)V PUBLIC LEAVE forge_at.cfg:73"
+    "net.minecraft.world.gen.structure.MapGenStructureIO METHOD func_143031_a(Ljava/lang/Class;Ljava/lang/String;)V PUBLIC LEAVE {cfgfile}:74",
+    "net.minecraft.world.gen.structure.MapGenStructureIO METHOD func_143034_b(Ljava/lang/Class;Ljava/lang/String;)V PUBLIC LEAVE {cfgfile}:73"
   ],
   "net.minecraft.world.gen.structure.MapGenVillage": [
-    "net.minecraft.world.gen.structure.MapGenVillage FIELD field_75055_e PUBLIC REMOVEFINAL forge_at.cfg:41"
+    "net.minecraft.world.gen.structure.MapGenVillage FIELD field_75055_e PUBLIC REMOVEFINAL {cfgfile}:41"
   ],
   "net.minecraft.world.gen.structure.StructureStrongholdPieces": [
-    "net.minecraft.world.gen.structure.StructureStrongholdPieces INNERCLASS Stronghold PUBLIC LEAVE forge_at.cfg:76"
+    "net.minecraft.world.gen.structure.StructureStrongholdPieces INNERCLASS Stronghold PUBLIC LEAVE {cfgfile}:76"
   ],
   "net.minecraft.world.gen.structure.StructureStrongholdPieces$Stronghold": [
-    "net.minecraft.world.gen.structure.StructureStrongholdPieces$Stronghold CLASS PUBLIC LEAVE forge_at.cfg:76"
+    "net.minecraft.world.gen.structure.StructureStrongholdPieces$Stronghold CLASS PUBLIC LEAVE {cfgfile}:76"
   ],
   "net.minecraft.world.gen.structure.StructureVillagePieces": [
-    "net.minecraft.world.gen.structure.StructureVillagePieces INNERCLASS Village PUBLIC LEAVE forge_at.cfg:88"
+    "net.minecraft.world.gen.structure.StructureVillagePieces INNERCLASS Village PUBLIC LEAVE {cfgfile}:88"
   ],
   "net.minecraft.world.gen.structure.StructureVillagePieces$Village": [
-    "net.minecraft.world.gen.structure.StructureVillagePieces$Village CLASS PUBLIC LEAVE forge_at.cfg:88"
+    "net.minecraft.world.gen.structure.StructureVillagePieces$Village CLASS PUBLIC LEAVE {cfgfile}:88"
   ],
   "net.minecraft.world.storage.SaveFormatOld": [
-    "net.minecraft.world.storage.SaveFormatOld FIELD field_75808_a PUBLIC LEAVE forge_at.cfg:193"
+    "net.minecraft.world.storage.SaveFormatOld FIELD field_75808_a PUBLIC LEAVE {cfgfile}:193"
   ],
   "net.minecraft.world.storage.loot.LootPool": [
-    "net.minecraft.world.storage.loot.LootPool FIELD field_186455_c PRIVATE REMOVEFINAL forge_at.cfg:271",
-    "net.minecraft.world.storage.loot.LootPool FIELD field_186456_d PRIVATE REMOVEFINAL forge_at.cfg:272"
+    "net.minecraft.world.storage.loot.LootPool FIELD field_186455_c PRIVATE REMOVEFINAL {cfgfile}:271",
+    "net.minecraft.world.storage.loot.LootPool FIELD field_186456_d PRIVATE REMOVEFINAL {cfgfile}:272"
   ]
 }


### PR DESCRIPTION
This PR backports #10 to AT 10.x to aid in debugging which mods a given AT comes from.