### PR TITLE
Add a way to look up which sources specify a certain target

### DIFF
--- a/src/main/java/net/neoforged/accesstransformer/AccessTransformerEngineImpl.java
+++ b/src/main/java/net/neoforged/accesstransformer/AccessTransformerEngineImpl.java
@@ -1,6 +1,7 @@
 package net.neoforged.accesstransformer;
 
 import net.neoforged.accesstransformer.api.AccessTransformerEngine;
+import net.neoforged.accesstransformer.api.TargetType;
 import net.neoforged.accesstransformer.parser.AccessTransformerList;
 import org.antlr.v4.runtime.CharStream;
 import org.objectweb.asm.Opcodes;
@@ -79,5 +80,10 @@ public class AccessTransformerEngineImpl implements AccessTransformerEngine {
     @Override
     public Set<Type> getTargets() {
         return masterList.getTargets();
+    }
+
+    @Override
+    public Set<String> getSourcesForTarget(final String className, final TargetType type, final String targetName) {
+        return masterList.getSourcesForTarget(className, type, targetName);
     }
 }

--- a/src/main/java/net/neoforged/accesstransformer/ClassTarget.java
+++ b/src/main/java/net/neoforged/accesstransformer/ClassTarget.java
@@ -1,5 +1,6 @@
 package net.neoforged.accesstransformer;
 
+import net.neoforged.accesstransformer.api.TargetType;
 import org.objectweb.asm.tree.*;
 
 import java.util.*;
@@ -23,5 +24,10 @@ public class ClassTarget extends Target<ClassNode> {
             inner.access = targetAccess.mergeWith(inner.access);
             inner.access = targetFinalState.mergeWith(inner.access);
         });
+    }
+
+    @Override
+    public boolean matches(final String className, final TargetType type, final String targetName) {
+        return type == TargetType.CLASS && getClassName().equals(className);
     }
 }

--- a/src/main/java/net/neoforged/accesstransformer/FieldTarget.java
+++ b/src/main/java/net/neoforged/accesstransformer/FieldTarget.java
@@ -1,5 +1,6 @@
 package net.neoforged.accesstransformer;
 
+import net.neoforged.accesstransformer.api.TargetType;
 import org.objectweb.asm.tree.*;
 
 import java.util.*;
@@ -47,5 +48,10 @@ public class FieldTarget extends Target<FieldNode> {
 
     public String getFieldName() {
         return fieldName;
+    }
+
+    @Override
+    public boolean matches(final String className, final TargetType type, final String targetName) {
+        return type == TargetType.FIELD && getClassName().equals(className) && fieldName.equals(targetName);
     }
 }

--- a/src/main/java/net/neoforged/accesstransformer/InnerClassTarget.java
+++ b/src/main/java/net/neoforged/accesstransformer/InnerClassTarget.java
@@ -1,15 +1,18 @@
 package net.neoforged.accesstransformer;
 
+import net.neoforged.accesstransformer.api.TargetType;
 import org.objectweb.asm.tree.*;
 
 import java.util.*;
 
 public class InnerClassTarget extends Target<ClassNode> {
+    private final String originalInnerName;
     private final String innerName;
 
     public InnerClassTarget(final String className, final String innerName) {
         super(className);
-        this.innerName = innerName;
+        this.originalInnerName = innerName;
+        this.innerName = innerName.replace('.', '/');
     }
 
     @Override
@@ -40,5 +43,10 @@ public class InnerClassTarget extends Target<ClassNode> {
             inner.access = targetAccess.mergeWith(inner.access);
             inner.access = targetFinalState.mergeWith(inner.access);
         });
+    }
+
+    @Override
+    public boolean matches(final String className, final TargetType type, final String targetName) {
+        return type == TargetType.CLASS && originalInnerName.equals(className);
     }
 }

--- a/src/main/java/net/neoforged/accesstransformer/MethodTarget.java
+++ b/src/main/java/net/neoforged/accesstransformer/MethodTarget.java
@@ -1,5 +1,6 @@
 package net.neoforged.accesstransformer;
 
+import net.neoforged.accesstransformer.api.TargetType;
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.*;
 
@@ -63,4 +64,8 @@ public class MethodTarget extends Target<MethodNode> {
 
     }
 
+    @Override
+    public boolean matches(final String className, final TargetType type, final String targetName) {
+        return type == TargetType.METHOD && getClassName().equals(className) && this.targetName.equals(targetName);
+    }
 }

--- a/src/main/java/net/neoforged/accesstransformer/Target.java
+++ b/src/main/java/net/neoforged/accesstransformer/Target.java
@@ -44,6 +44,14 @@ public abstract class Target<T> {
 
     public abstract String targetName();
 
+    /**
+     * Checks whether this target matches the given target description.
+     *
+     * @param className The FQN of the class containing the target
+     * @param type The type of the target
+     * @param targetName The name of the target (ignored for {@link TargetType#CLASS} and wildcard targets)
+     * @return whether this target matches the given target description
+     */
     public abstract boolean matches(final String className, final TargetType type, final String targetName);
 
     public abstract void apply(final T node, final AccessTransformer.Modifier targetAccess, final AccessTransformer.FinalState targetFinalState, Set<String> privateChanged);

--- a/src/main/java/net/neoforged/accesstransformer/Target.java
+++ b/src/main/java/net/neoforged/accesstransformer/Target.java
@@ -1,5 +1,6 @@
 package net.neoforged.accesstransformer;
 
+import net.neoforged.accesstransformer.api.TargetType;
 import org.objectweb.asm.*;
 
 import java.util.*;
@@ -42,5 +43,8 @@ public abstract class Target<T> {
     }
 
     public abstract String targetName();
+
+    public abstract boolean matches(final String className, final TargetType type, final String targetName);
+
     public abstract void apply(final T node, final AccessTransformer.Modifier targetAccess, final AccessTransformer.FinalState targetFinalState, Set<String> privateChanged);
 }

--- a/src/main/java/net/neoforged/accesstransformer/TargetType.java
+++ b/src/main/java/net/neoforged/accesstransformer/TargetType.java
@@ -1,5 +1,0 @@
-package net.neoforged.accesstransformer;
-
-public enum TargetType {
-    FIELD, METHOD, CLASS;
-}

--- a/src/main/java/net/neoforged/accesstransformer/WildcardTarget.java
+++ b/src/main/java/net/neoforged/accesstransformer/WildcardTarget.java
@@ -1,5 +1,6 @@
 package net.neoforged.accesstransformer;
 
+import net.neoforged.accesstransformer.api.TargetType;
 import org.objectweb.asm.*;
 import org.objectweb.asm.tree.*;
 
@@ -57,5 +58,10 @@ public class WildcardTarget extends Target<ClassNode> {
                 }
             }
         }
+    }
+
+    @Override
+    public boolean matches(final String className, final TargetType type, final String targetName) {
+        return type == this.type && getClassName().equals(className);
     }
 }

--- a/src/main/java/net/neoforged/accesstransformer/api/AccessTransformerEngine.java
+++ b/src/main/java/net/neoforged/accesstransformer/api/AccessTransformerEngine.java
@@ -45,6 +45,18 @@ public interface AccessTransformerEngine {
     Set<Type> getTargets();
 
     /**
+     * Looks up AT file sources of entries matching the given target
+     *
+     * @param className the class containing the target
+     * @param type the type of the target
+     * @param targetName the target's name (null for class targets, full descriptor for method targets, name for field targets)
+     * @return The list of sources specifying the given target or null if none apply
+     */
+    default Set<String> getSourcesForTarget(final String className, final TargetType type, final String targetName) {
+        return null;
+    }
+
+    /**
      * Attempts to transform the given {@code classNode}, and apply ATs, if any.
      * @param classNode the class to transform
      * @param name the name of the class

--- a/src/main/java/net/neoforged/accesstransformer/api/TargetType.java
+++ b/src/main/java/net/neoforged/accesstransformer/api/TargetType.java
@@ -1,0 +1,7 @@
+package net.neoforged.accesstransformer.api;
+
+public enum TargetType {
+    FIELD,
+    METHOD,
+    CLASS
+}

--- a/src/main/java/net/neoforged/accesstransformer/parser/AccessTransformVisitor.java
+++ b/src/main/java/net/neoforged/accesstransformer/parser/AccessTransformVisitor.java
@@ -28,7 +28,7 @@ public class AccessTransformVisitor extends AtParserBaseVisitor<Void> {
             int idx = className.lastIndexOf('$'); //Java uses this to identify inner classes, Scala/others use it for synthetics. Either way we should be fine as it will skip over classes that don't exist.
             if (idx != -1) {
                 String parent = className.substring(0, idx);
-                accessTransformers.add(new AccessTransformer(new InnerClassTarget(parent, className.replace('.', '/')), ModifierProcessor.modifier(modifier), ModifierProcessor.finalState(modifier), this.origin, ctx.getStart().getLine()));
+                accessTransformers.add(new AccessTransformer(new InnerClassTarget(parent, className), ModifierProcessor.modifier(modifier), ModifierProcessor.finalState(modifier), this.origin, ctx.getStart().getLine()));
             }
         }
         return super.visitEntry(ctx);

--- a/src/main/java/net/neoforged/accesstransformer/parser/AccessTransformerList.java
+++ b/src/main/java/net/neoforged/accesstransformer/parser/AccessTransformerList.java
@@ -1,5 +1,6 @@
 package net.neoforged.accesstransformer.parser;
 
+import net.neoforged.accesstransformer.api.TargetType;
 import net.neoforged.accesstransformer.generated.*;
 
 import net.neoforged.accesstransformer.*;
@@ -97,4 +98,17 @@ public class AccessTransformerList {
                 .collect(Collectors.groupingBy(o->o.getTarget().getType(), HashMap::new, Collectors.toMap(at->at.getTarget().targetName(), Function.identity())));
     }
 
+    public Set<String> getSourcesForTarget(final String className, final TargetType type, final String targetName) {
+        return accessTransformers.entrySet()
+                .stream()
+                .filter(e -> e.getKey().matches(className, type, targetName))
+                .map(Map.Entry::getValue)
+                .map(AccessTransformer::getOrigins)
+                .map(HashSet::new)
+                .reduce((s1, s2) -> {
+                    s1.addAll(s2);
+                    return s1;
+                })
+                .orElse(null);
+    }
 }

--- a/src/test/java/net/neoforged/accesstransformer/test/AccessTransformerPresenceTest.java
+++ b/src/test/java/net/neoforged/accesstransformer/test/AccessTransformerPresenceTest.java
@@ -1,0 +1,31 @@
+package net.neoforged.accesstransformer.test;
+
+import net.neoforged.accesstransformer.api.TargetType;
+import net.neoforged.accesstransformer.parser.AccessTransformerList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Set;
+
+public class AccessTransformerPresenceTest {
+    @Test
+    public void testSourceLookup() throws IOException, URISyntaxException {
+        final AccessTransformerList atLoader = new AccessTransformerList();
+        atLoader.loadFromResource("forge_at.cfg");
+
+        // Class
+        Assertions.assertEquals(Set.of("forge_at.cfg:99"), atLoader.getSourcesForTarget("net.minecraft.item.crafting.RecipeTippedArrow", TargetType.CLASS, null));
+        // Inner class
+        Assertions.assertEquals(Set.of("forge_at.cfg:76"), atLoader.getSourcesForTarget("net.minecraft.world.gen.structure.StructureStrongholdPieces$Stronghold", TargetType.CLASS, null));
+        // Method
+        Assertions.assertEquals(Set.of("forge_at.cfg:6"), atLoader.getSourcesForTarget("net.minecraft.block.Block", TargetType.METHOD, "func_149752_b(F)Lnet/minecraft/block/Block;"));
+        // Field
+        Assertions.assertEquals(Set.of("forge_at.cfg:22"), atLoader.getSourcesForTarget("net.minecraft.entity.EntityTrackerEntry", TargetType.FIELD, "field_73134_o"));
+        // Method wildcard
+        Assertions.assertEquals(Set.of("forge_at.cfg:29"), atLoader.getSourcesForTarget("net.minecraft.world.biome.Biome", TargetType.METHOD, "this_is_ignored(F)Ldoes/not/Matter;"));
+        // Field wildcard
+        Assertions.assertEquals(Set.of("forge_at.cfg:51"), atLoader.getSourcesForTarget("net.minecraft.world.biome.BiomeDecorator", TargetType.FIELD, "this_is_ignored"));
+    }
+}

--- a/src/test/java/net/neoforged/accesstransformer/test/AccessTransformerPresenceTest.java
+++ b/src/test/java/net/neoforged/accesstransformer/test/AccessTransformerPresenceTest.java
@@ -7,25 +7,30 @@ import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.Set;
 
 public class AccessTransformerPresenceTest {
     @Test
     public void testSourceLookup() throws IOException, URISyntaxException {
         final AccessTransformerList atLoader = new AccessTransformerList();
-        atLoader.loadFromResource("forge_at.cfg");
+
+        Path filePath = Path.of(getClass().getClassLoader().getResource("forge_at.cfg").toURI());
+        atLoader.loadFromPath(filePath);
+
+        String sourcePrefix = filePath.toString();
 
         // Class
-        Assertions.assertEquals(Set.of("forge_at.cfg:99"), atLoader.getSourcesForTarget("net.minecraft.item.crafting.RecipeTippedArrow", TargetType.CLASS, null));
+        Assertions.assertEquals(Set.of(sourcePrefix + ":99"), atLoader.getSourcesForTarget("net.minecraft.item.crafting.RecipeTippedArrow", TargetType.CLASS, null));
         // Inner class
-        Assertions.assertEquals(Set.of("forge_at.cfg:76"), atLoader.getSourcesForTarget("net.minecraft.world.gen.structure.StructureStrongholdPieces$Stronghold", TargetType.CLASS, null));
+        Assertions.assertEquals(Set.of(sourcePrefix + ":76"), atLoader.getSourcesForTarget("net.minecraft.world.gen.structure.StructureStrongholdPieces$Stronghold", TargetType.CLASS, null));
         // Method
-        Assertions.assertEquals(Set.of("forge_at.cfg:6"), atLoader.getSourcesForTarget("net.minecraft.block.Block", TargetType.METHOD, "func_149752_b(F)Lnet/minecraft/block/Block;"));
+        Assertions.assertEquals(Set.of(sourcePrefix + ":6"), atLoader.getSourcesForTarget("net.minecraft.block.Block", TargetType.METHOD, "func_149752_b(F)Lnet/minecraft/block/Block;"));
         // Field
-        Assertions.assertEquals(Set.of("forge_at.cfg:22"), atLoader.getSourcesForTarget("net.minecraft.entity.EntityTrackerEntry", TargetType.FIELD, "field_73134_o"));
+        Assertions.assertEquals(Set.of(sourcePrefix + ":22"), atLoader.getSourcesForTarget("net.minecraft.entity.EntityTrackerEntry", TargetType.FIELD, "field_73134_o"));
         // Method wildcard
-        Assertions.assertEquals(Set.of("forge_at.cfg:29"), atLoader.getSourcesForTarget("net.minecraft.world.biome.Biome", TargetType.METHOD, "this_is_ignored(F)Ldoes/not/Matter;"));
+        Assertions.assertEquals(Set.of(sourcePrefix + ":29"), atLoader.getSourcesForTarget("net.minecraft.world.biome.Biome", TargetType.METHOD, "this_is_ignored(F)Ldoes/not/Matter;"));
         // Field wildcard
-        Assertions.assertEquals(Set.of("forge_at.cfg:51"), atLoader.getSourcesForTarget("net.minecraft.world.biome.BiomeDecorator", TargetType.FIELD, "this_is_ignored"));
+        Assertions.assertEquals(Set.of(sourcePrefix + ":51"), atLoader.getSourcesForTarget("net.minecraft.world.biome.BiomeDecorator", TargetType.FIELD, "this_is_ignored"));
     }
 }


### PR DESCRIPTION
This PR adds a way to look up which sources specify a certain target. This is intended to be used to provide details when an AT causes a coremod to fail, such as when a failed operated on by the field-to-method transformer is made public.