### PR TITLE
Fix inner class AT application

### DIFF
--- a/src/main/java/net/neoforged/accesstransformer/InnerClassAccessTransformer.java
+++ b/src/main/java/net/neoforged/accesstransformer/InnerClassAccessTransformer.java
@@ -11,7 +11,7 @@ public class InnerClassAccessTransformer extends AccessTransformer<ClassNode> {
 
     public InnerClassAccessTransformer(final Target.InnerClassTarget target, final Transformation transformation) {
         super(target, transformation);
-        this.innerName = target.innerName();
+        this.innerName = target.innerName().replace('.', '/');
     }
 
     @Override

--- a/src/test/java/net/neoforged/accesstransformer/test/InnerClassModifierTest.java
+++ b/src/test/java/net/neoforged/accesstransformer/test/InnerClassModifierTest.java
@@ -1,0 +1,46 @@
+package net.neoforged.accesstransformer.test;
+
+import net.neoforged.accesstransformer.api.AccessTransformerEngine;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.tree.ClassNode;
+
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class InnerClassModifierTest {
+    @BeforeAll
+    public static void setup() {
+        Configurator.setRootLevel(Level.DEBUG);
+    }
+
+    /**
+     * Validate that the INNERCLASS metadata is correctly updated on the outer class.
+     */
+    @Test
+    public void testInnerClassModifierChangedOnParent() throws Exception {
+        AccessTransformerEngine engine = AccessTransformerEngine.newEngine();
+        engine.loadATFromResource("innerclass_at.cfg");
+        Type outerClass = Type.getObjectType("net.neoforged.accesstransformer.testJar.DefaultClass".replace('.', '/'));
+        Type innerClass = Type.getObjectType("net.neoforged.accesstransformer.testJar.DefaultClass$Inner".replace('.', '/'));
+        assertTrue(engine.containsClassTarget(outerClass));
+        assertTrue(engine.containsClassTarget(innerClass));
+        final ClassNode outerNode = new ClassNode();
+        try (InputStream is = Files.newInputStream(Path.of("build/classes/java/testJars/" + outerClass.getInternalName() + ".class"))) {
+            final ClassReader classReader = new ClassReader(is);
+            classReader.accept(outerNode, 0);
+        }
+        engine.transform(outerNode, outerClass);
+        outerNode.innerClasses.forEach(node -> {
+            assertTrue((node.access & Opcodes.ACC_PUBLIC) != 0);
+        });
+    }
+}

--- a/src/test/resources/innerclass_at.cfg
+++ b/src/test/resources/innerclass_at.cfg
@@ -1,0 +1,2 @@
+
+public net.neoforged.accesstransformer.testJar.DefaultClass$Inner


### PR DESCRIPTION
Previously the `InnerClassAccessTransformer` was having no effect due to a mismatch in the naming convention (ASM used `/`, our name was stored as a `.`).

Added a test case to prevent this from regressing in the future.